### PR TITLE
Don't skip URL encoding for any characters

### DIFF
--- a/src/main/webapp/WEB-INF/static/js/depict.js
+++ b/src/main/webapp/WEB-INF/static/js/depict.js
@@ -31,11 +31,6 @@ function update() {
 
 function depict_url(opts, smiles, w, h) {
 	var smi = encodeURIComponent(smiles);
-	// okay to not encode these
-	smi = smi.replace(/%3D/g, '=');
-	smi = smi.replace(/%5B/g, '[');
-	smi = smi.replace(/%5D/g, ']');
-	smi = smi.replace(/%40/g, '@');
 	var url = './depict/' + opts.style + '/svg?smi=' + smi;
 	if (w && h)
 	  url += '&w=' + w + '&h=' + h;


### PR DESCRIPTION
I am finding that newer versions of tomcat seem to be stricter about which characters are allowed in URLs. Specifically, square brackets in SMILES result in the following error:

     java.lang.IllegalArgumentException: Invalid character found in the request target. The valid characters are defined in RFC 7230 and RFC 3986

It looks like there are workarounds, but it seems safest to just fully encode all SMILES strings.