### PR TITLE
Fix MOLfile input

### DIFF
--- a/cdkdepict-lib/src/main/java/org/openscience/cdk/app/DepictController.java
+++ b/cdkdepict-lib/src/main/java/org/openscience/cdk/app/DepictController.java
@@ -33,7 +33,6 @@ import org.openscience.cdk.renderer.generators.standard.StandardGenerator.Visibi
 import org.openscience.cdk.sgroup.Sgroup;
 import org.openscience.cdk.sgroup.SgroupKey;
 import org.openscience.cdk.sgroup.SgroupType;
-import org.openscience.cdk.silent.AtomContainer;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmiFlavor;
 import org.openscience.cdk.smiles.SmilesGenerator;
@@ -818,7 +817,7 @@ public class DepictController {
   {
     if (str.contains("V2000")) {
       try (MDLV2000Reader mdlr = new MDLV2000Reader(new StringReader(str))) {
-        return mdlr.read(new AtomContainer(0, 0, 0, 0));
+        return mdlr.read(builder.newAtomContainer());
       } catch (CDKException | IOException e3) {
         throw new CDKException("Could not parse input");
       }


### PR DESCRIPTION
When building locally, I found that the following change was needed to ensure AtomContainer2 was used for MOLfile input. Otherwise, an error was raised when iterating over the bonds of an atom in calcValence (it would be an Atom instead of AtomRef).

The public version of cdkdepict doesn't seem to have this problem, so I don't fully understand what's going on. But I think this change to use the builder is a better way of doing it anyway?