### PR TITLE
feat: include maven in docker build, allow nonroot users of container.

### DIFF
--- a/docker/Dockerfile_dev
+++ b/docker/Dockerfile_dev
@@ -1,11 +1,4 @@
-FROM maven:3.5-jdk-8-alpine as builder
-WORKDIR /usr/src/app
-COPY cdkdepict-lib cdkdepict-lib
-COPY cdkdepict-webapp cdkdepict-webapp
-COPY pom.xml pom.xml
-RUN mvn clean package
-
-FROM openjdk:8u212-jre-alpine as runtime
+FROM openjdk:8u212-jre-alpine
 
 # we need a font! DejaVu does fine but we only want the Sans-Serif one
 RUN apk add --no-cache ttf-dejavu && \
@@ -16,7 +9,7 @@ RUN apk add --no-cache ttf-dejavu && \
     /usr/share/fonts/ttf-dejavu/DejaVuSans-* \
     /usr/share/fonts/ttf-dejavu/DejaVuMath*
 WORKDIR /usr/src/app
-COPY --from=builder /usr/src/app/cdkdepict-webapp/target/cdkdepict-*.war cdkdepict.war
+COPY cdkdepict.war .
 RUN chgrp -R 0 /usr/src/app && chmod -R g=u /usr/src/app
 EXPOSE 8080
 ENTRYPOINT ["java",  "-Dserver.port=8080", "-jar", "cdkdepict.war"]

--- a/docker/README
+++ b/docker/README
@@ -1,11 +1,18 @@
-Build
+Build from source
+=====
+To build the 'cdk/depict' image directly from source (including the MAVEN build)
+
+	$ docker build -t cdkdepict -f Dockerfile .
+
+
+Build from a local jar
 =====
 
-To build the 'cdk/depict' container copy the JAR file built with MAVEN 
+To build the 'cdk/depict' image, copy the JAR file built with MAVEN 
 to the directory with the Docker file.
 
 	$ cp ../cdkdepict-webapp/target/cdkdepict*.war cdkdepict.war
-	$ docker build -t cdkdepict -f Dockerfile .
+	$ docker build -t cdkdepict -f Dockerfile_dev .
 
 Alternatively run the 'build.sh' script.
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,4 +4,4 @@ cd ../ && \
     mvn install -DskipTests && \
     cd docker && \
     cp ../cdkdepict-webapp/target/cdkdepict*.war cdkdepict.war && \
-    docker build -t cdkdepict -f Dockerfile .
+    docker build -t cdkdepict -f Dockerfile_dev .


### PR DESCRIPTION
Hi!

I wanted to quickly rebuilt the docker image and saw the instructions require the jar file to be available locally.
The download of that doesn't work by the way.

In the PR I replace the Dockerfile with one where the maven build is done in Docker as a previous step. This should not affect the size of the image. I also added a different directory to not have stuff in the root directory, giving it permissions per best practices.

I left a dev version of the Dockerfile that works with the build.sh to keep the option to use local jar files.
