### PR TITLE
explicit constraint about .sdf (V2000)

### DIFF
--- a/cdkdepict-webapp/src/main/webapp/WEB-INF/static/depict.html
+++ b/cdkdepict-webapp/src/main/webapp/WEB-INF/static/depict.html
@@ -18,7 +18,7 @@
 </div>
 <div class="center">  
   <div class="header"> 
-    Generate depictions of molecules and reactions from <a href="https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system">SMILES</a> or <a href="https://en.wikipedia.org/wiki/Chemical_table_file">SDF</a>.
+    Generate depictions of molecules and reactions from <a href="https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system">SMILES</a> or <a href="https://en.wikipedia.org/wiki/Chemical_table_file">SDF (V2000 format)</a>.
            <a style="position: absolute; right: 0; top: 0;"
           href="https://github.com/cdk/depict"><img
            src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>


### PR DESCRIPTION
Structures to process may be provided as SMILES (preferred), or .sdf (as fall back).  Because there are two formats of the later, it is better to explicitly indicate the user if s/he opts for the later, then only V2000 is an acceptable input.[1]

[1] https://github.com/cdk/depict/issues/53