### PR TITLE
Be explicit with the spring-boot-maven-plugin version

### DIFF
--- a/cdkdepict-webapp/pom.xml
+++ b/cdkdepict-webapp/pom.xml
@@ -112,6 +112,7 @@
           <plugin>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-maven-plugin</artifactId>
+            <version>2.7.3</version>
             <configuration>
               <mainClass>org.openscience.cdk.app.Application</mainClass>
               <layout>WAR</layout>


### PR DESCRIPTION
With the recent release of Spring Boot 3; this will default to that version and break the JDK{8,11} GitHub Actions since Spring Boot 3 is targeted for JDK 17 bytecode.